### PR TITLE
Adds docker service bridge

### DIFF
--- a/bundle/09-docker-network-bridge.yaml
+++ b/bundle/09-docker-network-bridge.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dockerhost
+spec:
+  type: ExternalName
+  externalName: host.docker.internal


### PR DESCRIPTION
Allows ability to connect to other docker containers running on the host machine, but outside the KinD cluster.